### PR TITLE
feat(Team): 팀 생성 API 구현

### DIFF
--- a/src/main/java/com/sparta/taskflow/domain/team/controller/TeamController.java
+++ b/src/main/java/com/sparta/taskflow/domain/team/controller/TeamController.java
@@ -1,0 +1,28 @@
+package com.sparta.taskflow.domain.team.controller;
+
+import com.sparta.taskflow.common.response.ApiResponse;
+import com.sparta.taskflow.domain.team.dto.TeamRequestDto;
+import com.sparta.taskflow.domain.team.dto.TeamResponseDto;
+import com.sparta.taskflow.domain.team.service.external.TeamCommandService;
+import com.sparta.taskflow.domain.team.service.external.TeamQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/teams")
+@RequiredArgsConstructor
+public class TeamController {
+
+    private final TeamCommandService teamCommandService;
+    private final TeamQueryService teamQueryService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<TeamResponseDto.Create>> createTeam(
+            @RequestBody TeamRequestDto.Create requestDto) {
+        TeamResponseDto.Create responseDto = teamCommandService.createTeam(requestDto);
+
+        return ApiResponse.created(responseDto, "팀이 성공적으로 생성되었습니다.");
+    }
+}

--- a/src/main/java/com/sparta/taskflow/domain/team/dto/TeamRequestDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/team/dto/TeamRequestDto.java
@@ -1,6 +1,7 @@
 package com.sparta.taskflow.domain.team.dto;
 
 import com.sparta.taskflow.domain.team.entity.Team;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,6 +9,7 @@ public class TeamRequestDto {
 
     @Getter
     @NoArgsConstructor
+    @AllArgsConstructor
     public static class Create {
         private String name;
         private String description;

--- a/src/main/java/com/sparta/taskflow/domain/team/dto/TeamRequestDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/team/dto/TeamRequestDto.java
@@ -1,0 +1,22 @@
+package com.sparta.taskflow.domain.team.dto;
+
+import com.sparta.taskflow.domain.team.entity.Team;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TeamRequestDto {
+
+    @Getter
+    @NoArgsConstructor
+    public static class Create {
+        private String name;
+        private String description;
+
+        public Team toEntity() {
+            return Team.builder()
+                    .name(this.name)
+                    .description(this.description)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/sparta/taskflow/domain/team/dto/TeamResponseDto.java
+++ b/src/main/java/com/sparta/taskflow/domain/team/dto/TeamResponseDto.java
@@ -1,0 +1,32 @@
+package com.sparta.taskflow.domain.team.dto;
+
+import com.sparta.taskflow.domain.team.entity.Team;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+public class TeamResponseDto {
+
+    @Getter
+    public static class Create {
+        private final Long id;
+        private final String name;
+        private final String description;
+        private final LocalDateTime createdAt;
+        private final List<Object> members;
+
+        private Create(Team team) {
+            this.id = team.getId();
+            this.name = team.getName();
+            this.description = team.getDescription();
+            this.createdAt = team.getCreatedAt();
+            this.members = Collections.emptyList();
+        }
+
+        public static Create from(Team team) {
+            return new Create(team);
+        }
+    }
+}

--- a/src/main/java/com/sparta/taskflow/domain/team/entity/Team.java
+++ b/src/main/java/com/sparta/taskflow/domain/team/entity/Team.java
@@ -5,18 +5,35 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Team extends BaseEntity {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @Column(nullable = false, unique = true)
     private String name;
 
     private String description;
+
+    // 양방향 연관 관계 설정
+    @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TeamMember> teamMembers = new ArrayList<>();
+
+    @Builder
+    public Team(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    // 팀 멤버 수 반환
+    public int getMemberCount() {
+        return teamMembers.size();
+    }
 }

--- a/src/main/java/com/sparta/taskflow/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/sparta/taskflow/domain/team/repository/TeamRepository.java
@@ -1,0 +1,10 @@
+package com.sparta.taskflow.domain.team.repository;
+
+import com.sparta.taskflow.domain.team.entity.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TeamRepository extends JpaRepository<Team, Long> {
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/sparta/taskflow/domain/team/service/external/TeamCommandService.java
+++ b/src/main/java/com/sparta/taskflow/domain/team/service/external/TeamCommandService.java
@@ -1,0 +1,32 @@
+package com.sparta.taskflow.domain.team.service.external;
+
+import com.sparta.taskflow.domain.team.dto.TeamRequestDto;
+import com.sparta.taskflow.domain.team.dto.TeamResponseDto;
+import com.sparta.taskflow.domain.team.entity.Team;
+import com.sparta.taskflow.domain.team.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TeamCommandService {
+    private final TeamRepository teamRepository;
+
+    public TeamResponseDto.Create createTeam(TeamRequestDto.Create requestDto){
+        // 팀 이름 중복 확인
+        if(teamRepository.existsByName(requestDto.getName())){
+            throw new IllegalArgumentException("팀 이름이 이미 존재합니다.");
+        }
+
+        // DTO -> Entity 변환
+        Team newTeam = requestDto.toEntity();
+
+        // DB에 저장
+        Team savedTeam = teamRepository.save(newTeam);
+
+        // Entity -> DTO 변환 후 반환
+        return TeamResponseDto.Create.from(savedTeam);
+    }
+}

--- a/src/main/java/com/sparta/taskflow/domain/team/service/external/TeamQueryService.java
+++ b/src/main/java/com/sparta/taskflow/domain/team/service/external/TeamQueryService.java
@@ -1,0 +1,11 @@
+package com.sparta.taskflow.domain.team.service.external;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamQueryService {
+}

--- a/src/main/java/com/sparta/taskflow/domain/team/service/internal/TeamInternalService.java
+++ b/src/main/java/com/sparta/taskflow/domain/team/service/internal/TeamInternalService.java
@@ -1,0 +1,11 @@
+package com.sparta.taskflow.domain.team.service.internal;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamInternalService {
+}

--- a/src/test/java/com/sparta/taskflow/domain/team/service/TeamCommandServiceTest.java
+++ b/src/test/java/com/sparta/taskflow/domain/team/service/TeamCommandServiceTest.java
@@ -1,0 +1,88 @@
+package com.sparta.taskflow.domain.team.service;
+
+import com.sparta.taskflow.domain.team.dto.TeamRequestDto;
+import com.sparta.taskflow.domain.team.dto.TeamResponseDto;
+import com.sparta.taskflow.domain.team.entity.Team;
+import com.sparta.taskflow.domain.team.repository.TeamRepository;
+import com.sparta.taskflow.domain.team.service.external.TeamCommandService;
+import com.sparta.taskflow.utils.TestUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TeamCommandServiceTest {
+
+    @Mock
+    private TeamRepository teamRepository;
+
+    @InjectMocks
+    private TeamCommandService teamCommandService;
+
+    @Test
+    @DisplayName("팀 생성에 성공한다.")
+    void createTeam_success() {
+        // given
+        TeamRequestDto.Create request = new TeamRequestDto.Create(
+                "Test Team",
+                "This is a test team."
+        );
+
+        // TestUtils를 사용하여 save 후 반환될 Team 엔티티 객체 생성
+        LocalDateTime createdAt = LocalDateTime.of(2025, 9, 4, 15, 30);
+        Team team = TestUtils.createEntity(Team.class, Map.of(
+                "id", 1L,
+                "name", "Test Team",
+                "description", "This is a test team.",
+                "createdAt", createdAt
+        ));
+
+        given(teamRepository.existsByName(anyString())).willReturn(false);
+        given(teamRepository.save(any(Team.class))).willReturn(team);
+
+        // when
+        TeamResponseDto.Create response = teamCommandService.createTeam(request);
+
+        // then
+        assertThat(response)
+                .extracting("id", "name", "description", "createdAt")
+                .contains(1L, "Test Team", "This is a test team.", createdAt);
+
+        verify(teamRepository, times(1)).existsByName(anyString());
+        verify(teamRepository, times(1)).save(any(Team.class));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 팀명이 있으면 팀 생성을 할 수 없다.")
+    void createTeam_fail_whenDuplicateTeamName() {
+        // given
+        TeamRequestDto.Create request = new TeamRequestDto.Create(
+                "Existing Team",
+                "This team already exists."
+        );
+
+        // when
+        when(teamRepository.existsByName(request.getName())).thenReturn(true);
+
+        // then
+        assertThatThrownBy(() -> teamCommandService.createTeam(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("팀 이름이 이미 존재합니다");
+
+        // save 메서드가 호출되지 않았는지 검증
+        verify(teamRepository, never()).save(any(Team.class));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
팀 생성 API 구현
팀 생성 성공 및 팀 명 중복 에러 테스트

## 🔗 연관된 이슈


## ✅ PR 유형

- [x] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외