### PR TITLE
fix(config) : @EnableJpaAuditing 중복 선언 수정

### DIFF
--- a/src/main/java/com/sparta/taskflow/TaskFlowApplication.java
+++ b/src/main/java/com/sparta/taskflow/TaskFlowApplication.java
@@ -2,10 +2,8 @@ package com.sparta.taskflow;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class TaskFlowApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sparta/taskflow/domain/user/service/UserInternalService.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/service/UserInternalService.java
@@ -1,9 +1,7 @@
 package com.sparta.taskflow.domain.user.service;
 
 import com.sparta.taskflow.domain.user.entity.User;
-import org.springframework.stereotype.Component;
 
-@Component
 public interface UserInternalService {
     //ID로 User 조회
     //다중 유저 조회 기능은 제외

--- a/src/main/java/com/sparta/taskflow/domain/user/service/UserInternalServiceImpl.java
+++ b/src/main/java/com/sparta/taskflow/domain/user/service/UserInternalServiceImpl.java
@@ -1,0 +1,21 @@
+package com.sparta.taskflow.domain.user.service;
+
+import com.sparta.taskflow.domain.user.entity.User;
+import com.sparta.taskflow.domain.user.exception.UserErrorCode;
+import com.sparta.taskflow.domain.user.exception.UserNotFoundException;
+import com.sparta.taskflow.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserInternalServiceImpl implements UserInternalService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public User getByIdOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(UserErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
<!---- 변경 사항 및 관련 이슈 예시
- 컨트롤러 API 수정
- Entity 생성자 추가
- 등등
-->
- @EnableJpaAuditing 중복 선언 수정
```
Description:

The bean 'jpaAuditingHandler' could not be registered. A bean with that name has already been defined and overriding is disabled.
```
<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
<!---- Related to: #(Isuue Number) -->

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외