### PR TITLE
fix: 활동 로그 버그 수정

### DIFF
--- a/src/main/java/com/sparta/taskflow/domain/activitylog/controller/ActivityLogController.java
+++ b/src/main/java/com/sparta/taskflow/domain/activitylog/controller/ActivityLogController.java
@@ -1,7 +1,6 @@
 package com.sparta.taskflow.domain.activitylog.controller;
 
 import com.sparta.taskflow.common.response.ApiPageResponse;
-import com.sparta.taskflow.common.response.ApiResponse;
 import com.sparta.taskflow.domain.activitylog.dto.reponse.ActivityLogResponse;
 import com.sparta.taskflow.domain.activitylog.dto.reponse.MyActivityResponse;
 import com.sparta.taskflow.domain.activitylog.enums.ActivityType;
@@ -18,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/activities")
@@ -30,8 +29,8 @@ public class ActivityLogController {
     @GetMapping
     public ResponseEntity<ApiPageResponse<ActivityLogResponse>> getActivityLogs(@RequestParam(required = false) ActivityType type,
                                                                                 @RequestParam(required = false) Long taskId,
-                                                                                @RequestParam(required = false) LocalDateTime startDate,
-                                                                                @RequestParam(required = false) LocalDateTime endDate,
+                                                                                @RequestParam(required = false) LocalDate startDate,
+                                                                                @RequestParam(required = false) LocalDate endDate,
                                                                                 @RequestParam(defaultValue = "0") int page,
                                                                                 @RequestParam(defaultValue = "10") int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());

--- a/src/main/java/com/sparta/taskflow/domain/activitylog/repository/ActivityLogRepositoryCustom.java
+++ b/src/main/java/com/sparta/taskflow/domain/activitylog/repository/ActivityLogRepositoryCustom.java
@@ -5,9 +5,9 @@ import com.sparta.taskflow.domain.activitylog.enums.ActivityType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public interface ActivityLogRepositoryCustom {
 
-    Page<ActivityLog> search(ActivityType type, Long taskId, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+    Page<ActivityLog> search(ActivityType type, Long taskId, LocalDate startDate, LocalDate endDate, Pageable pageable);
 }

--- a/src/main/java/com/sparta/taskflow/domain/activitylog/repository/ActivityLogRepositoryImpl.java
+++ b/src/main/java/com/sparta/taskflow/domain/activitylog/repository/ActivityLogRepositoryImpl.java
@@ -11,7 +11,8 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,15 +23,15 @@ public class ActivityLogRepositoryImpl implements ActivityLogRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Page<ActivityLog> search(ActivityType type, Long taskId, LocalDateTime startDate, LocalDateTime endDate, Pageable pageable) {
+    public Page<ActivityLog> search(ActivityType type, Long taskId, LocalDate startDate, LocalDate endDate, Pageable pageable) {
         QActivityLog activityLog = QActivityLog.activityLog;
 
         BooleanBuilder builder = new BooleanBuilder();
 
         if (type != null) builder.and(activityLog.type.eq(type));
         if (taskId != null) builder.and(activityLog.taskId.eq(taskId));
-        if (startDate != null) builder.and(activityLog.createdAt.goe(startDate));
-        if (endDate != null) builder.and(activityLog.createdAt.loe(endDate));
+        if (startDate != null) builder.and(activityLog.createdAt.goe(startDate.atStartOfDay()));
+        if (endDate != null) builder.and(activityLog.createdAt.loe(endDate.atTime(LocalTime.MAX)));
 
         List<ActivityLog> content = jpaQueryFactory
                 .selectFrom(activityLog)

--- a/src/main/java/com/sparta/taskflow/domain/activitylog/service/internal/ActivityLogInternalServiceImpl.java
+++ b/src/main/java/com/sparta/taskflow/domain/activitylog/service/internal/ActivityLogInternalServiceImpl.java
@@ -16,7 +16,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -34,8 +34,8 @@ public class ActivityLogInternalServiceImpl implements ActivityLogInternalServic
 
     public Page<ActivityLog> getActivityLogs(ActivityType type,
                                              Long taskId,
-                                             LocalDateTime startDate,
-                                             LocalDateTime endDate,
+                                             LocalDate startDate,
+                                             LocalDate endDate,
                                              Pageable pageable) {
         return activityLogRepository.search(type, taskId, startDate, endDate, pageable);
     }

--- a/src/main/java/com/sparta/taskflow/domain/task/entity/Task.java
+++ b/src/main/java/com/sparta/taskflow/domain/task/entity/Task.java
@@ -78,10 +78,6 @@ public class Task extends BaseEntity {
         this.assignee = assignee;
     }
 
-    public void updateStatus(TaskStatus status) {
-        this.status = status;
-    }
-
     //Task 삭제 검증
     public void validateTaskNotDeleted() {
         if (isDeleted()) {

--- a/src/main/java/com/sparta/taskflow/domain/task/service/TaskService.java
+++ b/src/main/java/com/sparta/taskflow/domain/task/service/TaskService.java
@@ -86,12 +86,11 @@ public class TaskService {
     public TaskResponse updateStatus(Long taskId, StatusRequest statusRequest, Long loginUserId) {
         Task task = taskRepository.findTaskByIdOrThrow(taskId);
         task.validateTaskNotDeleted();
-        task.recordEndDate(statusRequest.getStatus());
 
         TaskStatus ordStatus = task.getStatus();
         TaskStatus newStatus = statusRequest.getStatus();
 
-        task.updateStatus(newStatus);
+        task.recordEndDate(newStatus);
 
         activityLogInternalServiceImpl.log(ActivityType.TASK_STATUS_CHANGED, loginUserId, taskId, ordStatus, newStatus);
 


### PR DESCRIPTION
## 📝 작업 내용
- 작업 상태 변경 시 OldStatus 값이 제대로 반영되지 않는 오류를 수정했습니다.
- 중복되는 task.updateStatus 메서드를 삭제하였습니다. (refactoring)
- 활동 로그 일별 조회 시 입력값을 제대로 변환하지 못하는 오류를 수정하였습니다. (LocalDateTime -> DateTime)

- 이때, 시작일 <= 종료일 검증 어노테이션을 추가할 예정입니다.

<!---- 스크린샷 (선택) -->

## 🔗 연관된 이슈
<!---- Related to: #(Isuue Number) -->

<!---- 리뷰 요구사항 (선택) -->

<!---- 현재 버그 (선택) -->

## ✅ PR 유형

- [x] 코드 리팩토링
- [x] 버그 수정